### PR TITLE
ボタンの編集

### DIFF
--- a/app/assets/stylesheets/modules/_new_book.scss
+++ b/app/assets/stylesheets/modules/_new_book.scss
@@ -63,7 +63,7 @@
       .btn {
         display: inline-block;
         text-align: center;
-        width: 300px;
+        width: 500px;
         border:2px solid  ;
         font-size: 16px;
         text-decoration: none;

--- a/app/assets/stylesheets/modules/_new_book.scss
+++ b/app/assets/stylesheets/modules/_new_book.scss
@@ -60,22 +60,27 @@
         margin: 5px 10px;
         border:1px solid #ccc;
       }
-      .btn {
-        display: inline-block;
-        text-align: center;
-        width: 500px;
-        border:2px solid  ;
-        font-size: 16px;
-        text-decoration: none;
-        font-weight: bold;
-        padding: 8px 16px;
-        border-radius: 10px;
-        color: #FFF;
-        margin-top: 20px;
-        background-color: #00bcd4;
-      }
-      .btn:hover {
-        background-color: #018091;
+      .bottom {
+        width: 100%;
+        max-width: 500px;
+        margin: 0 auto;
+        .btn {
+          display: inline-block;
+          text-align: center;
+          width: 100%;
+          border:2px solid  ;
+          font-size: 16px;
+          text-decoration: none;
+          font-weight: bold;
+          padding: 8px 16px;
+          border-radius: 10px;
+          color: #FFF;
+          margin-top: 20px;
+          background-color: #00bcd4;
+        }
+        .btn:hover {
+          background-color: #018091;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/modules/_show_book.scss
+++ b/app/assets/stylesheets/modules/_show_book.scss
@@ -33,13 +33,13 @@
       color: lightsalmon;
     }
   }
-  .showPage-bottom {
+  .bottom {
     width: 100%;
-    margin: 0 auto;
     max-width: 500px;
+    margin: 0 auto;
     .detail-btn {
       display: inline-block;
-      width: 500px;
+      width: 100%;
       border: 2px solid;
       font-size: 16px;
       padding: 15px 16px 12px 16px;

--- a/app/assets/stylesheets/modules/_show_book.scss
+++ b/app/assets/stylesheets/modules/_show_book.scss
@@ -3,6 +3,7 @@
   text-align: center;
   font-family: 'Khand', sans-serif;
   color: dimgray;
+
   &__book-name {
     padding: 30px 0;
     font-size: 40px;
@@ -32,19 +33,24 @@
       color: lightsalmon;
     }
   }
-  .detail-btn {
-    display: inline-block;
-    width: 500px;
-    border: 2px solid;
-    font-size: 16px;
-    padding: 15px 16px 12px 16px;
-    font-weight: bold;
-    border-radius: 10px;
-    color: #fff;
-    background-color: #00bcd4;
-    margin: 0 10px;
-  }
-  .detail-btn:hover {
-  background-color: #018091;
+  .showPage-bottom {
+    width: 100%;
+    margin: 0 auto;
+    max-width: 500px;
+    .detail-btn {
+      display: inline-block;
+      width: 500px;
+      border: 2px solid;
+      font-size: 16px;
+      padding: 15px 16px 12px 16px;
+      font-weight: bold;
+      border-radius: 10px;
+      color: #fff;
+      background-color: #00bcd4;
+      margin: 0 10px;
+    }
+    .detail-btn:hover {
+    background-color: #018091;
+    }
   }
 }

--- a/app/views/books/_books_form.html.erb
+++ b/app/views/books/_books_form.html.erb
@@ -60,12 +60,14 @@
         <div class="title3">最後にこの本を要約し人に説明するための文章を作成してください。</div>
         <%= form.text_area :derection, class: "books_summery" %>
         <div class="question">入力お疲れ様でした。</div>
+      <div class="bottom">
         <% if @book.persisted?%>
-          <%= form.submit "変更する", class: "btn"%>
-        <% else %>
-          <%= form.submit "保存する", class: "btn"%>
+            <%= form.submit "変更する", class: "btn"%>
+          <% else %>
+            <%= form.submit "保存する", class: "btn"%>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -7,8 +7,7 @@
     <p><%= @book.author %></p>
     <div class="questions__title">ジャンル</div>
     <p><%= @book.genre.name %></p>
-    <div class="questions__question">この本は何について問題としていますか？またその問題を解決する方法は？
-</div>
+    <div class="questions__question">この本は何について問題としていますか？またその問題を解決する方法は？</div>
     <div class="questions-detail"><%= @book.output_tweets1 %></div>
     <div class="questions__question">この本はどのように始まり、どのように終わりましたか？（本の構造は？）</div>
     <div class="questions-detail"><%= @book.output_tweets2 %></div>
@@ -52,7 +51,9 @@
     <div class="questions__title3">あなたが作成した、この本の要約</div>
     <div class="questions-detail"><%= @book.derection %></div>
   </div>
-  <%= link_to "マイページに戻る", user_path, class: "detail-btn" %>
-  <%= link_to "編集する", edit_book_path, class: "detail-btn" %>
-  <%= link_to "この本を削除する", book_path, method: :delete, class: "detail-btn" %>
+  <div class="showPage-bottom">
+    <%= link_to "マイページに戻る", user_path, class: "detail-btn" %>
+    <%= link_to "編集する", edit_book_path, class: "detail-btn" %>
+    <%= link_to "この本を削除する", book_path, method: :delete, class:   "detail-btn" %>
+  </div>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -51,7 +51,7 @@
     <div class="questions__title3">あなたが作成した、この本の要約</div>
     <div class="questions-detail"><%= @book.derection %></div>
   </div>
-  <div class="showPage-bottom">
+  <div class="bottom">
     <%= link_to "マイページに戻る", user_path, class: "detail-btn" %>
     <%= link_to "編集する", edit_book_path, class: "detail-btn" %>
     <%= link_to "この本を削除する", book_path, method: :delete, class:   "detail-btn" %>


### PR DESCRIPTION
#What
全てのページのボタンのViewの崩れを修正
また、画面のサイズに応じてボタンのサイズが変わるようにボタンに親要素を作成し、max-width: 500px;、margin: 0 auto;　を当て、子要素であるボタン本体の width を 100% に指定する。

#Why
修正前は画面サイズが大きいと上二つのボタンのみ横並びになってしまっており、綺麗に表示されなかっため、ボタンが全て縦並びになり、尚且つ画面のサイズに応じてボタンの大きさが変化するようにするように変更。

before
![localhost_3000_books_1](https://user-images.githubusercontent.com/67489015/99327931-60ed6500-28be-11eb-9a58-cb0e5191c2fd.png)

after
![localhost_3000_books_1 (1)](https://user-images.githubusercontent.com/67489015/99327958-71054480-28be-11eb-9952-4f13e2fa4005.png)

![localhost_3000_books_new](https://user-images.githubusercontent.com/67489015/99327983-7ebaca00-28be-11eb-8428-bcdd4397f02e.png)

お手数をおかけしますが、コードレビューをお願い致します。